### PR TITLE
Make `Data.List.NonEmpty.toUnfoldable` and `Data.List.Lazy.NonEmpty.toUnfoldable` work with `Unfoldable1`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Breaking changes:
 
 New features:
 
+- Change `NonEmpty.toUnfoldable` to produce any `Unfoldable1` (#218 by @UnrelatedString)
+
 Bugfixes:
 
 Other improvements:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ Breaking changes:
 
 New features:
 
-- Change `NonEmpty.toUnfoldable` to produce any `Unfoldable1` (#218 by @UnrelatedString)
+- Change `NonEmpty.toUnfoldable` to produce any `Unfoldable1` (#220 by @UnrelatedString)
 
 Bugfixes:
 

--- a/src/Data/List/Lazy/NonEmpty.purs
+++ b/src/Data/List/Lazy/NonEmpty.purs
@@ -28,11 +28,11 @@ import Data.List.Lazy.Types (NonEmptyList(..))
 import Data.Maybe (Maybe(..), maybe, fromMaybe)
 import Data.NonEmpty ((:|))
 import Data.Tuple (Tuple(..))
-import Data.Unfoldable (class Unfoldable, unfoldr)
+import Data.Unfoldable1 (class Unfoldable1, unfoldr1)
 
-toUnfoldable :: forall f. Unfoldable f => NonEmptyList ~> f
+toUnfoldable :: forall f. Unfoldable1 f => NonEmptyList ~> f
 toUnfoldable =
-  unfoldr (\xs -> (\rec -> Tuple rec.head rec.tail) <$> L.uncons xs) <<< toList
+  unfoldr1 (\rec -> Tuple rec.head $ L.uncons rec.tail) <<< uncons
 
 fromFoldable :: forall f a. Foldable f => f a -> Maybe (NonEmptyList a)
 fromFoldable = fromList <<< L.fromFoldable

--- a/src/Data/List/NonEmpty.purs
+++ b/src/Data/List/NonEmpty.purs
@@ -71,7 +71,7 @@ import Data.NonEmpty ((:|))
 import Data.NonEmpty as NE
 import Data.Semigroup.Traversable (sequence1)
 import Data.Tuple (Tuple(..), fst, snd)
-import Data.Unfoldable (class Unfoldable, unfoldr)
+import Data.Unfoldable1 (class Unfoldable1, unfoldr1)
 import Partial.Unsafe (unsafeCrashWith)
 
 import Data.Foldable (foldl, foldr, foldMap, fold, intercalate, elem, notElem, find, findMap, any, all) as Exports
@@ -111,9 +111,12 @@ wrappedOperation2 name f (NonEmptyList (x :| xs)) (NonEmptyList (y :| ys)) =
 lift :: forall a b. (L.List a -> b) -> NonEmptyList a -> b
 lift f (NonEmptyList (x :| xs)) = f (x : xs)
 
-toUnfoldable :: forall f. Unfoldable f => NonEmptyList ~> f
-toUnfoldable =
-  unfoldr (\xs -> (\rec -> Tuple rec.head rec.tail) <$> L.uncons xs) <<< toList
+toUnfoldable :: forall f. Unfoldable1 f => NonEmptyList ~> f
+toUnfoldable  =
+  unfoldr1 (\rec -> Tuple rec.head $ L.uncons rec.tail) <<< uncons 
+
+
+  -- unfoldr (\xs -> (\rec -> Tuple rec.head rec.tail) <$> L.uncons xs) <<< toList
 
 fromFoldable :: forall f a. Foldable f => f a -> Maybe (NonEmptyList a)
 fromFoldable = fromList <<< L.fromFoldable

--- a/src/Data/List/NonEmpty.purs
+++ b/src/Data/List/NonEmpty.purs
@@ -112,11 +112,8 @@ lift :: forall a b. (L.List a -> b) -> NonEmptyList a -> b
 lift f (NonEmptyList (x :| xs)) = f (x : xs)
 
 toUnfoldable :: forall f. Unfoldable1 f => NonEmptyList ~> f
-toUnfoldable  =
+toUnfoldable =
   unfoldr1 (\rec -> Tuple rec.head $ L.uncons rec.tail) <<< uncons 
-
-
-  -- unfoldr (\xs -> (\rec -> Tuple rec.head rec.tail) <$> L.uncons xs) <<< toList
 
 fromFoldable :: forall f a. Foldable f => f a -> Maybe (NonEmptyList a)
 fromFoldable = fromList <<< L.fromFoldable

--- a/test/Test/Data/List.purs
+++ b/test/Test/Data/List.purs
@@ -6,7 +6,7 @@ import Data.Array as Array
 import Data.Foldable (class Foldable, foldMap, foldl)
 import Data.FoldableWithIndex (foldMapWithIndex, foldlWithIndex, foldrWithIndex)
 import Data.Function (on)
-import Data.List (List(..), Pattern(..), alterAt, catMaybes, concat, concatMap, delete, deleteAt, deleteBy, drop, dropEnd, dropWhile, elemIndex, elemLastIndex, filter, filterM, findIndex, findLastIndex, foldM, fromFoldable, group, groupAll, groupAllBy, groupBy, head, init, insert, insertAt, insertBy, intersect, intersectBy, last, length, mapMaybe, modifyAt, nub, nubBy, nubByEq, nubEq, null, partition, range, reverse, singleton, snoc, sort, sortBy, span, stripPrefix, tail, take, takeEnd, takeWhile, transpose, uncons, union, unionBy, unsnoc, unzip, updateAt, zip, zipWith, zipWithA, (!!), (..), (:), (\\))
+import Data.List (List(..), Pattern(..), alterAt, catMaybes, concat, concatMap, delete, deleteAt, deleteBy, drop, dropEnd, dropWhile, elemIndex, elemLastIndex, filter, filterM, findIndex, findLastIndex, foldM, fromFoldable, group, groupAll, groupAllBy, groupBy, head, init, insert, insertAt, insertBy, intersect, intersectBy, last, length, mapMaybe, modifyAt, nub, nubBy, nubByEq, nubEq, null, partition, range, reverse, singleton, snoc, sort, sortBy, span, stripPrefix, tail, take, takeEnd, takeWhile, toUnfoldable, transpose, uncons, union, unionBy, unsnoc, unzip, updateAt, zip, zipWith, zipWithA, (!!), (..), (:), (\\))
 import Data.List.NonEmpty as NEL
 import Data.Maybe (Maybe(..), isNothing, fromJust)
 import Data.Monoid.Additive (Additive(..))
@@ -410,6 +410,9 @@ testList = do
 
   log "append should be stack-safe"
   void $ pure $ xs <> xs
+
+  log "toUnfoldable should agree with Unfoldable List"
+  assert $ (1..5) == toUnfoldable (1..5)
 
 step :: Int -> Maybe (Tuple Int Int)
 step 6 = Nothing

--- a/test/Test/Data/List/Lazy.purs
+++ b/test/Test/Data/List/Lazy.purs
@@ -469,7 +469,7 @@ testListLazy = do
   assert $ Just 1 == toUnfoldable (iterate (_ + 1) 1)
 
   log "toUnfoldable should work ok on infinite NEL"
-  assert $ Just 1 == NEL.toUnfoldable (nel $ 1 :| iterate (_ + 1) 2) -- Bit odd that `iterate` doesn't produce a NEL as is, but I suppose the whole thing's an afterthought
+  assert $ Just 1 == NEL.toUnfoldable (NEL.iterate (_ + 1) 1)
 
 step :: Int -> Maybe (Tuple Int Int)
 step 6 = Nothing

--- a/test/Test/Data/List/Lazy.purs
+++ b/test/Test/Data/List/Lazy.purs
@@ -8,7 +8,7 @@ import Data.FoldableWithIndex (foldMapWithIndex, foldlWithIndex, foldrWithIndex)
 import Data.Function (on)
 import Data.FunctorWithIndex (mapWithIndex)
 import Data.Lazy as Z
-import Data.List.Lazy (List, Pattern(..), alterAt, catMaybes, concat, concatMap, cycle, cons, delete, deleteAt, deleteBy, drop, dropWhile, elemIndex, elemLastIndex, filter, filterM, findIndex, findLastIndex, foldM, foldMap, foldl, foldr, foldrLazy, fromFoldable, group, groupBy, head, init, insert, insertAt, insertBy, intersect, intersectBy, iterate, last, length, mapMaybe, modifyAt, nil, nub, nubBy, nubEq, nubByEq, null, partition, range, repeat, replicate, replicateM, reverse, scanlLazy, singleton, slice, snoc, span, stripPrefix, tail, take, takeWhile, transpose, uncons, union, unionBy, unzip, updateAt, zip, zipWith, zipWithA, (!!), (..), (:), (\\))
+import Data.List.Lazy (List, Pattern(..), alterAt, catMaybes, concat, concatMap, cycle, cons, delete, deleteAt, deleteBy, drop, dropWhile, elemIndex, elemLastIndex, filter, filterM, findIndex, findLastIndex, foldM, foldMap, foldl, foldr, foldrLazy, fromFoldable, group, groupBy, head, init, insert, insertAt, insertBy, intersect, intersectBy, iterate, last, length, mapMaybe, modifyAt, nil, nub, nubBy, nubEq, nubByEq, null, partition, range, repeat, replicate, replicateM, reverse, scanlLazy, singleton, slice, snoc, span, stripPrefix, tail, take, takeWhile, toUnfoldable, transpose, uncons, union, unionBy, unzip, updateAt, zip, zipWith, zipWithA, (!!), (..), (:), (\\))
 import Data.List.Lazy.NonEmpty as NEL
 import Data.Maybe (Maybe(..), isNothing, fromJust)
 import Data.Monoid.Additive (Additive(..))
@@ -458,6 +458,18 @@ testListLazy = do
 
   log "unfoldr1 should maintain order for NEL"
   assert $ (nel (1 :| l [2, 3, 4, 5])) == unfoldr1 step1 1
+
+  log "toUnfoldable should agree with Unfoldable List"
+  assert $ (1..5) == toUnfoldable (1..5)
+
+  log "toUnfoldable should agree with Unfoldable1 NEL"
+  assert $ nel (1 :| (2..5)) == NEL.toUnfoldable (nel (1 :| (2..5)))
+
+  log "toUnfoldable should work ok on infinite List"
+  assert $ Just 1 == toUnfoldable (iterate (_ + 1) 1)
+
+  log "toUnfoldable should work ok on infinite NEL"
+  assert $ Just 1 == NEL.toUnfoldable (nel $ 1 :| iterate (_ + 1) 2) -- Bit odd that `iterate` doesn't produce a NEL as is, but I suppose the whole thing's an afterthought
 
 step :: Int -> Maybe (Tuple Int Int)
 step 6 = Nothing

--- a/test/Test/Data/List/NonEmpty.purs
+++ b/test/Test/Data/List/NonEmpty.purs
@@ -281,6 +281,9 @@ testNonEmptyList = do
   log "unfoldr1 should maintain order"
   assert $ (nel 1 [2, 3, 4, 5]) == unfoldr1 step1 1
 
+  log "toUnfoldable should agree with Unfoldable1 NEL"
+  assert $ nel 1 [2, 3, 4, 5] == NEL.toUnfoldable (nel 1 [2, 3, 4, 5])
+
 step1 :: Int -> Tuple Int (Maybe Int)
 step1 n = Tuple n (if n >= 5 then Nothing else Just (n + 1))
 


### PR DESCRIPTION
**Description of the change**

Modified `toUnfoldable` in `Data.List.NonEmpty` and `Data.List.Lazy.NonEmpty` to have the signature `toUnfoldable :: forall f. Unfoldable1 f => NonEmptyList ~> f`, and reimplemented it accordingly. Additionally added tests covering all four `toUnfoldable`s, since apparently there were no such tests in the existing codebase.

The motivation for this PR is that some users may hypothetically wish to convert known non-empty lists into other structures which cannot be empty. This can be addressed unobtrusively because `Unfoldable1` is a superclass of `Unfoldable`; the old type signature is completely compatible with the new implementation. For lack of a real use case, I was inspired to contribute this change when developing an even more superfluous package of my own which pervasively concerns itself with laziness in unfoldables.

Did not bump the version--although I don't think I could have made any breaking changes, I still changed the types of two functions in the public API (and the only relevant tests are ones I wrote), and either way I assume versioning decisions are best left to package maintainers.

---

**Checklist:**

- [x] Added the change to the changelog's "Unreleased" section with a reference to this PR (e.g. "- Made a change (#0000)")
- [x] Linked any existing issues or proposals that this pull request should close
- [ ] Updated or added relevant documentation
- [x] Added a test for the contribution (if applicable)
